### PR TITLE
Updating terraform 0.11.7->0.11.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 
 MAINTAINER stkhr
 
-ENV TERRAFORM_VERSION=0.11.7
+ENV TERRAFORM_VERSION=0.11.10
 
 RUN apk -U add \
     ca-certificates \


### PR DESCRIPTION
Tested locally, seems to work.   Would be awesome if you could merge/push to docker hub.

bemo@asimov:~/gitroot/terraform-awscli-container>docker run -it tf-cli:latest
/ # terraform --version
Terraform v0.11.10



